### PR TITLE
reference for federated users to Access to Their S3 Home Directory

### DIFF
--- a/doc_source/reference_policies_examples_s3_home-directory-console.md
+++ b/doc_source/reference_policies_examples_s3_home-directory-console.md
@@ -2,6 +2,13 @@
 
 This example shows how you might create a policy that allows IAM users to access their own home directory in S3\. The home directory is a bucket that includes a `home` folder and folders for individual users\. This policy also provides the permissions necessary to complete this action on the console\. To use this policy, replace the red text in the example policy with your own information\.
 
+Use `${aws:userid}` instead of `${aws:username}` to allows a federated user with IAM role to access their own home directory in S3. The value for the aws:userid variable should be "role id:caller-specified-name".
+
++ role-id is a unique identifier assigned to each role at creation. You can display the role ID with the AWS CLI command: `aws iam get-role --role-name rolename`   
++ caller-specified-name names that are passed by the calling process (such as an application or service) when it makes a call to get temporary credentials.
+
+For example, if you specify the friendly name Bob, the correct format would be "AROAXXT2NJT7D3SIQN7Z6:Bob". This names your session and allows access to the S3 bucket with a matching prefix. 
+
 ```
 {
   "Version": "2012-10-17",

--- a/doc_source/reference_policies_examples_s3_home-directory-console.md
+++ b/doc_source/reference_policies_examples_s3_home-directory-console.md
@@ -7,7 +7,7 @@ Use `${aws:userid}` instead of `${aws:username}` to allows a federated user with
 + role-id is a unique identifier assigned to each role at creation. You can display the role ID with the AWS CLI command: `aws iam get-role --role-name rolename`   
 + caller-specified-name names that are passed by the calling process (such as an application or service) when it makes a call to get temporary credentials.
 
-For example, if you specify the friendly name Bob, the correct format would be "AROAXXT2NJT7D3SIQN7Z6:Bob". This names your session and allows access to the S3 bucket with a matching prefix. 
+For example, if you specify the friendly name Bob, the correct format would be `"AROAXXT2NJT7D3SIQN7Z6:Bob"`. This names your session and allows access to the S3 bucket with a matching prefix. 
 
 ```
 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There is no clear documentation for restrict access to Web/SAML federated users with IAM Role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
