### PR TITLE
adds listing of aws service principals

### DIFF
--- a/doc_source/reference_policies_elements_principal.md
+++ b/doc_source/reference_policies_elements_principal.md
@@ -155,6 +155,8 @@ In these examples, the asterisk \(\*\) is used as a placeholder for Everyone/Ano
 ## More Information<a name="Principal_more-info"></a>
 
 For more information, see the following:
+
++ [Full Listing of AWS Service Principals](reference_service_principals_listing.md)
 + [Bucket Policy Examples](http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) in the *Amazon Simple Storage Service Developer Guide*
 + [Example Policies for Amazon SNS](http://docs.aws.amazon.com/sns/latest/dg/UsingIAMwithSNS.html#ExamplePolicies_SNS) in the *Amazon Simple Notification Service Developer Guide*
 + [Amazon SQS Policy Examples](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSExamples.html) in the *Amazon Simple Queue Service Developer Guide*

--- a/doc_source/reference_service_principals_listing.md
+++ b/doc_source/reference_service_principals_listing.md
@@ -1,0 +1,61 @@
+# Full AWS Service Principals Listing
+
+The following table lists the service principals of the AWS services, for information on using these in IAM policies refer to [IAM JSON Policy Elements: Principal](reference_policies_elements_principal.md).
+
+| Service | Principal|
+| ------- | -------- |
+| AWS Certificate Manager | acm.amazonaws.com |
+| Amazon API Gateway | apigateway.amazonaws.com |
+| Amazon Athena | athena.amazonaws.com |
+| AWS Auto Scaling | autoscaling.amazonaws.com |
+| Amazon Cloud Directory | clouddirectory.amazonaws.com |
+| AWS CloudFormation | cloudformation.amazonaws.com |
+| Amazon CloudFront | cloudfront.amazonaws.com |
+| Amazon CloudSearch | cloudsearch.amazonaws.com |
+| AWS CloudTrail | cloudtrail.amazonaws.com |
+| Amazon CloudWatch | monitoring.amazonaws.com |
+| Amazon CloudWatch Events | events.amazonaws.com |
+| Amazon CloudWatch Logs | logs.amazonaws.com |
+| AWS CodeCommit | codecommit.amazonaws.com |
+| AWS CodeDeploy | codedeploy.amazonaws.com |
+| AWS CodePipeline | codepipeline.amazonaws.com |
+| AWS Config | config.amazonaws.com | 
+| Amazon Data Pipeline | datapipeline.amazonaws.com |
+| AWS Direct Connect | directconnect.amazonaws.com |
+| AWS Directory Service | ds.amazonaws.com |
+| Amazon DynamoDB | dynamodb.amazonaws.com |
+| Amazon Elastic Compute Cloud (EC2) | ec2.amazonaws.com |
+| Amazon Elastic Container Registry (ECR) | ecr.amazonaws.com |
+| Amazon Elastic Container Services (ECS) | ecs.amazonaws.com |
+| AWS Lambda@Edge | edgelambda.amazonaws.com |
+| Amazon ElastiCache | elasticache.amazonaws.com |
+| AWS Elastic Beanstalk | elasticbeanstalk.amazonaws.com |
+| Amazon Elastic File System (EFS) | elasticfilesystem.amazonaws.com |
+| AWS Elastic Load Balancing | elasticloadbalancing.amazonaws.com |
+| Amazon Elastic MapReduce (EMR) | elasticmapreduce.amazonaws.com |
+| AWS Health | health.amazonaws.com |
+| AWS Identity and Access Management (IAM) | iam.amazonaws.com |
+| Amazon Inspector | inspector.amazonaws.com |
+| Amazon Kinesis | kinesis.amazonaws.com |
+| AWS Key Management Service (KMS) | kms.amazonaws.com |
+| AWS Lambda | lambda.amazonaws.com |
+| Amazon Lightsail | lightsail.amazonaws.com |
+| AWS OpsWorks | opsworks.amazonaws.com |
+| AWS Organizations | organizations.amazonaws.com |
+| Amazon Relational Database Service (RDS) | rds.amazonaws.com |
+| Amazon Redshift | redshift.amazonaws.com |
+| Amazon Route53 | route53.amazonaws.com |
+| Amazon Simple Storage Service (S3) | s3.amazonaws.com |
+| AWS Service Catalog | servicecatalog.amazonaws.com |
+| Amazon Simple Email Service (SES) | ses.amazonaws.com |
+| AWS Signin | signin.amazonaws.com |
+| Amazon Simple Notification Service (SNS) | sns.amazonaws.com |
+| Amazon Simple Queue Service (SQS) | sqs.amazonaws.com |
+| AWS Systems Manager (SSM) | ssm.amazonaws.com |
+| AWS Storage Gateway | storagegateway.amazonaws.com |
+| AWS Security Token Service (STS) | sts.amazonaws.com | 
+| AWS Support | support.amazonaws.com |
+| VM Import/Export | vmie.amazonaws.com |
+| AWS WAF | waf.amazonaws.com |
+| Amazon WorkDocs | worksdocs.amazonaws.com |
+| Amazon WorkSpaces | workspaces.amazonaws.com |


### PR DESCRIPTION
*Issue #, if available:*

There is no single reference location to find all the service principals, previously I was maintaining a gist list for reference.

*Description of changes:*

Adds a single reference location to find all current service principals in a browser "find" friendly manner. Also adds a link in the policy reference for principals.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
