### PR TITLE
Fixed typo in example policy for IAM

### DIFF
--- a/doc_source/reference_policies_examples_iam_limit-managed.md
+++ b/doc_source/reference_policies_examples_iam_limit-managed.md
@@ -9,7 +9,7 @@ This example shows how you might create a policy that limits customer managed an
     {
       "Effect": "Allow",
       "Action": [
-        "iam:ChangePasword",
+        "iam:ChangePassword",
         "iam:CreateAccessKey",
         "iam:CreateLoginProfile",
         "iam:CreateUser",


### PR DESCRIPTION
*Description of changes:*

There was a typo in example policy. AWS management console didn't recognize `"iam:ChangePasword"`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
