### PR TITLE
Word change: "know" to "control"

### DIFF
--- a/doc_source/id_roles_create_for-user_externalid.md
+++ b/doc_source/id_roles_create_for-user_externalid.md
@@ -85,7 +85,7 @@ Example Corp gives the external ID value of "12345" to you\. You must then add a
 }
 ```
 
-The Condition element in this policy allows Example Corp to assume the role only when the AssumeRole API call includes the external ID value of "12345"\. Example Corp makes sure that whenever it assumes a role on behalf of a customer, it always includes that customer's external ID value in the AssumeRole call\. Even if another customer supplies Example Corp with your ARN, it cannot know the external ID that Example Corp includes in its request to AWS\. This helps prevent an unauthorized customer from gaining access to your resources, as shown in the following diagram\.
+The Condition element in this policy allows Example Corp to assume the role only when the AssumeRole API call includes the external ID value of "12345"\. Example Corp makes sure that whenever it assumes a role on behalf of a customer, it always includes that customer's external ID value in the AssumeRole call\. Even if another customer supplies Example Corp with your ARN, it cannot control the external ID that Example Corp includes in its request to AWS\. This helps prevent an unauthorized customer from gaining access to your resources, as shown in the following diagram\.
 
 ![\[How to mitigate a confused deputy problem.\]](http://docs.aws.amazon.com/IAM/latest/UserGuide/)![\[How to mitigate a confused deputy problem.\]](http://docs.aws.amazon.com/IAM/latest/UserGuide/)![\[How to mitigate a confused deputy problem.\]](http://docs.aws.amazon.com/IAM/latest/UserGuide/)
 


### PR DESCRIPTION
This seems wrong.  External IDs aren't secret, so it's reasonable to expect "Another AWS Account" in the example to know the "Your AWS Account" external ID provided by "Example Corp" in the AssumeRole request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
