### PR TITLE
Fixed wording for IfExists condition docs

### DIFF
--- a/doc_source/reference_policies_elements_condition_operators.md
+++ b/doc_source/reference_policies_elements_condition_operators.md
@@ -261,7 +261,7 @@ The following example shows a policy you need to attach to any Amazon SNS queue 
 
 ## \.\.\.IfExists Condition Operators<a name="Conditions_IfExists"></a>
 
-You can add `IfExists` to the end of any condition operator name except the `Null` condition—for example, `StringLikeIfExists`\. You do this to say "If the policy key is present in the context of the request, process the key as specified in the policy\. If the key is not present, the condition evaluate the condition element as true\." Other condition elements in the statement can still result in a nonmatch, but not a missing key when checked with `...IfExists`\.
+You can add `IfExists` to the end of any condition operator name except the `Null` condition—for example, `StringLikeIfExists`\. You do this to say "If the policy key is present in the context of the request, process the key as specified in the policy\. If the key is not present, evaluate the condition element as true\." Other condition elements in the statement can still result in a nonmatch, but not a missing key when checked with `...IfExists`\.
 
 **Example using `IfExists`**
 


### PR DESCRIPTION

*Issue #, if available:*

No issue. This is a trivial docs change.

*Description of changes:*

There were two extraneous words in the docs explaining how IfExists condition operators work. More specifically, this change removes the string "the condition " from the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
