### PR TITLE
Update access_policies_boundaries.md

### DIFF
--- a/doc_source/access_policies_boundaries.md
+++ b/doc_source/access_policies_boundaries.md
@@ -293,7 +293,7 @@ Each statement serves a different purpose:
 
 1. The `CloudWatchLimited` statement allows Zhang to perform five actions in CloudWatch\. His permissions boundary allows all actions in CloudWatch, so his effective CloudWatch permissions are limited only by his permissions policy\.
 
-1. The `S3BucketContents` statement allows Zhang to list the `ZhangBucket` Amazon S3 bucket\. However, his permissions boundary does not allow any Amazon S3 action, he cannot perform any S3 operations, regardless of his permissions policy\.
+1. The `S3BucketContents` statement allows Zhang to list the `ZhangBucket` Amazon S3 bucket\. His permissions boundary deny all actions in S3 only on `logs` bucket, so he can only list his own `ZhangBucket` bucket as per his permissions policy.
 
 María then attaches the `DelegatedUserPermissions` policy as the permissions policy for the `Zhang` user\. 
 


### PR DESCRIPTION
The boundary is only denying actions on S3 logs bucket, so Zhang will be able to list his own ZhangBucket bucket as per his permissions policy.

*Issue #, if available:*

*Description of changes:*
Only changed the wording explaining that Zhang will be able to only list his own bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
