### PR TITLE
API Gateway supports resource based policy

### DIFF
--- a/doc_source/reference_aws-services-that-work-with-iam.md
+++ b/doc_source/reference_aws-services-that-work-with-iam.md
@@ -69,7 +69,7 @@ The AWS services listed below are grouped by their [AWS product categories](http
 |  |  |  |  |  |  |  | 
 | --- |--- |--- |--- |--- |--- |--- |
 |  Service  |  Actions  |  Resource\-level permissions  | Resource\-based policies |  Authorization based on tags  |  Temporary credentials  |  Service\-linked roles  | 
-|  [Amazon API Gateway](http://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html)  | Yes | Yes | No | No | Yes | No | 
+|  [Amazon API Gateway](http://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html)  | Yes | Yes | Yes | No | Yes | No | 
 |   [Amazon CloudFront](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/index.html?UsingWithIAM.html)   | Yes¹ | No | No | No | Yes | No | 
 |  [AWS Direct Connect](http://docs.aws.amazon.com/directconnect/latest/UserGuide/using_iam.html)  | Yes | No | No | No | Yes | No | 
 |  [Amazon Route 53](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide//auth-and-access-control.html)  | Yes | Yes | No | No | Yes | No | 


### PR DESCRIPTION
*Description of changes:*
As per Docs (and reality) AWS API Gateway supports resource based policies:
https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies.html
Changed the flag from No to yes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
