### PR TITLE
Added support for yubikey integration

### DIFF
--- a/doc_source/tutorial_users-self-manage-mfa-and-creds.md
+++ b/doc_source/tutorial_users-self-manage-mfa-and-creds.md
@@ -101,6 +101,7 @@ This example policy does not allow users to reset a password while signing in\. 
                ],
                "Resource": [
                    "arn:aws:iam::*:mfa/${aws:username}",
+                   "arn:aws:iam::*:u2f/${aws:username}",
                    "arn:aws:iam::*:user/${aws:username}"
                ]
            },
@@ -112,6 +113,7 @@ This example policy does not allow users to reset a password while signing in\. 
                ],
                "Resource": [
                    "arn:aws:iam::*:mfa/${aws:username}",
+                   "arn:aws:iam::*:u2f/${aws:username}",
                    "arn:aws:iam::*:user/${aws:username}"
                ],
                "Condition": {


### PR DESCRIPTION
Added constraints that users are also allowed (when they are self managed) to use an yubikey instead of an HW/SW MFA Token.

*Issue #, if available:*
Not able to configure/disable yubikey instead of a hardware MFA token or a virtual authenticator with the shown policy.

*Description of changes:*
Added another resource block to the policy. "arn:aws:iam::*:mfa/${aws:username}",

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
