### PR TITLE
Set correct ARN in Resource Type format

### DIFF
--- a/doc_source/list_amazonroute53autonaming.md
+++ b/doc_source/list_amazonroute53autonaming.md
@@ -24,7 +24,7 @@ The following resource types are defined by this service and can be used in the 
 
 | Resource Types | ARN | Condition Keys | 
 | --- | --- | --- | 
-|   namespace  |  arn:$\{Partition\}:servicediscovery:$\{Region\}:$\{Account\}:stack/$\{NamespaceName\}  |  | 
+|   namespace  |  arn:$\{Partition\}:servicediscovery:$\{Region\}:$\{Account\}:namespace/$\{NamespaceName\}  |  | 
 |   service  |  arn:$\{Partition\}:servicediscovery:$\{Region\}:$\{Account\}:service/$\{ServiceName\}  |  | 
 
 ## Condition Keys for Amazon Route 53 Auto Naming<a name="amazonroute53autonaming-policy-keys"></a>


### PR DESCRIPTION
I think this should be `namespace` and not `stack`?

*Issue #, if available:*

*Description of changes:*
Change the resource type in the ARN example for service discovery

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
