### PR TITLE
Fixed JSON syntax in IAM policy

### DIFF
--- a/doc_source/tutorial_users-self-manage-mfa-and-creds.md
+++ b/doc_source/tutorial_users-self-manage-mfa-and-creds.md
@@ -94,7 +94,7 @@ This example policy does not allow users to reset a password while signing in\. 
                "Effect": "Allow",
                "Action": [
                    "iam:CreateVirtualMFADevice",
-                   "iam:DeactivateMFADevice"
+                   "iam:DeactivateMFADevice",
                    "iam:DeleteVirtualMFADevice",
                    "iam:EnableMFADevice",
                    "iam:ListMFADevices",
@@ -110,7 +110,7 @@ This example policy does not allow users to reset a password while signing in\. 
                "Effect": "Deny",
                "NotAction": [
                    "iam:CreateVirtualMFADevice",
-                   "iam:DeactivateMFADevice"
+                   "iam:DeactivateMFADevice",
                    "iam:DeleteVirtualMFADevice",
                    "iam:ListVirtualMFADevices",
                    "iam:EnableMFADevice",


### PR DESCRIPTION
Policy to Enforce MFA Sign-In was missing commas after "iam:DeactivateMFADevice" in two different places.

*Issue #, if available:*
Invalid JSON syntax in example

*Description of changes:*
Added missing commas where applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
