### PR TITLE
Missing comma in IAM Policy JSON

### DIFF
--- a/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage.md
+++ b/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage.md
@@ -34,7 +34,7 @@ This policy does not allow users to view the **Users** page in the IAM console o
             "Effect": "Allow",
             "Action": [
                 "iam:GetAccountPasswordPolicy",
-                "iam:GetAccountSummary"       
+                "iam:GetAccountSummary",
                 "iam:ListVirtualMFADevices"
             ],
             "Resource": "*"


### PR DESCRIPTION
Missing comma, copy / paste results in syntax error

*Description of changes:*
Fixed missing comma from reference JSON to allow copy / paste use

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
