### PR TITLE
An equals sign is missing in the policy grammar

### DIFF
--- a/doc_source/reference_policies_grammar.md
+++ b/doc_source/reference_policies_grammar.md
@@ -109,7 +109,7 @@ policy  = {
     ("*" | [<resource_string>, <resource_string>, ...])
 
 <condition_block> = "Condition" : { <condition_map> }
-<condition_map> { 
+<condition_map> = { 
   <condition_type_string> : { <condition_key_string> : <condition_value_list> },
   <condition_type_string> : { <condition_key_string> : <condition_value_list> }, ...
 }  


### PR DESCRIPTION
*Description of changes: The policy grammar is not valid. An equals sign is missing for the rule <condition_map>.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
