### PR TITLE
An [] was missing from trust policy.

### DIFF
--- a/doc_source/id_roles_create_for-idp_saml.md
+++ b/doc_source/id_roles_create_for-idp_saml.md
@@ -22,12 +22,12 @@ Before you can create a role for SAML 2\.0 federation, you must first complete t
    ```
    {
        "Version": "2012-10-17",
-       "Statement": {
+       "Statement": [{
          "Effect": "Allow",
          "Action": "sts:AssumeRoleWithSAML",
          "Principal": {"Federated": "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:saml-provider/PROVIDER-NAME"},
          "Condition": {"StringEquals": {"SAML:aud": "https://signin.aws.amazon.com/saml"}}
-       }
+       }]
      }
    ```
 


### PR DESCRIPTION
*Issue #* Policy doesn't contain [] bracket hence getting an error while using it.
*Error* This policy contains the following error: Has prohibited field Principal For more information about the IAM policy grammar, see AWS IAM Policies

*Description of changes:* Added [] to the policy so that it will work properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
