### PR TITLE
Update EC2 cross account role trust policies example

### DIFF
--- a/doc_source/id_roles_use_switch-role-ec2.md
+++ b/doc_source/id_roles_use_switch-role-ec2.md
@@ -148,7 +148,7 @@ The `abcd` role must allow the Amazon EC2 service to assume the role\. To do thi
             "Sid": "abcdTrustPolicy",
             "Effect": "Allow",
             "Action": "sts:AssumeRole",
-            "Principal": {"AWS": "arn:aws:iam::111111111111:role/abcd"}
+            "Principal": {"Service": "ec2.amazonaws.com"}
         }
     ]
 }
@@ -199,7 +199,7 @@ The `efgh` role must allow the `abcd` instance profile role to assume it\. To do
             "Sid": "efghTrustPolicy",
             "Effect": "Allow",
             "Action": "sts:AssumeRole",
-            "Principal": {"Service": "ec2.amazonaws.com"}
+            "Principal": {"AWS": "arn:aws:iam::111111111111:role/abcd"}
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Swapped the principals in the trust policies for the example of an EC2 running with a role and allowing it to assume a role in another account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
