### PR TITLE
Fix typo -- singular to plural

### DIFF
--- a/doc_source/reference_policies_elements_principal.md
+++ b/doc_source/reference_policies_elements_principal.md
@@ -107,7 +107,7 @@ If your `Principal` element in a role trust policy contains an ARN that points t
 
 **AWS service**
 
-IAM roles that can be assumed by an AWS service are called *[service roles](id_roles_terms-and-concepts.md#iam-term-service-role)*\. Service roles must include a trust policy\. *Trust policies* are resource\-based policies that are attached to a role that define which principals can assume the role\. Some service role have predefined trust policies\. However, in some cases, you must specify the service principal in the trust policy\. A *service principal* is an identifier that is used to grant permissions to a service\. The identifier includes the long version of a service name, and is usually in the following format:
+IAM roles that can be assumed by an AWS service are called *[service roles](id_roles_terms-and-concepts.md#iam-term-service-role)*\. Service roles must include a trust policy\. *Trust policies* are resource\-based policies that are attached to a role that define which principals can assume the role\. Some service roles have predefined trust policies\. However, in some cases, you must specify the service principal in the trust policy\. A *service principal* is an identifier that is used to grant permissions to a service\. The identifier includes the long version of a service name, and is usually in the following format:
 
 `long_service-name.amazonaws.com`
 


### PR DESCRIPTION
*Issue #, if available:*
Typo

*Description of changes:*
Fixed typo - singular to plural
**Before**: Some service role have
**After**: Some service roles have


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
