### PR TITLE
missing a carriage return in the python sample

### DIFF
--- a/doc_source/id_roles_providers_enable-console-custom-url.md
+++ b/doc_source/id_roles_providers_enable-console-custom-url.md
@@ -181,7 +181,8 @@ if sys.version_info[0] < 3:
 else:
     def quote_plus_function(s):
         return urllib.parse.quote_plus(s)
-request_parameters += "&Session=" + quote_plus_function(json_string_with_temp_credentials)request_url = "https://signin.aws.amazon.com/federation" + request_parameters
+request_parameters += "&Session=" + quote_plus_function(json_string_with_temp_credentials)
+request_url = "https://signin.aws.amazon.com/federation" + request_parameters
 r = requests.get(request_url)
 # Returns a JSON document with a single element named SigninToken.
 signin_token = json.loads(r.text)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The python code runs with an error because it's missing a carriage return between two lines of code. I see it running fine now with the lines properly separated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
