### PR TITLE
Fix anonymous users description

### DIFF
--- a/doc_source/reference_policies_elements_principal.md
+++ b/doc_source/reference_policies_elements_principal.md
@@ -163,7 +163,7 @@ The following are equivalent:
 ```
 
 **Important**  
-In these examples, the asterisk \(\*\) is used as a placeholder for Everyone/Anonymous\. You cannot use it as a wildcard to match part of a name or an ARN\. We also strongly recommend that you do not use a wildcard in the `Principal` element in a role's trust policy unless you otherwise restrict access through a `Condition` element in the policy\. Otherwise, any IAM user in any account can access the role\.
+In these examples, the asterisk \(\*\) is used as a placeholder for Everyone/Anonymous\. You cannot use it as a wildcard to match part of a name or an ARN\. We also strongly recommend that you do not use a wildcard in the `Principal` element in a role's trust policy unless you otherwise restrict access through a `Condition` element in the policy\. Otherwise, any account in the partition can access the role\.
 
 ## More Information<a name="Principal_more-info"></a>
 


### PR DESCRIPTION
The original emphasized *user* entities being able to access the role, but ignored *role* entities.  
Also, originally failed to mention this being limited to accounts within the trusting account's aws partition.  So (e.g.) an aws-cn account can't trust a standard partition (aws) account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Separately - calling this *Anonymous Users (Public)* seems kinda misleading, as it suggests that unauthenticated principals can use the role, which I don't think holds here.