### PR TITLE
Updating  Data Catalog ARN

### DIFF
--- a/doc_source/list_awsglue.md
+++ b/doc_source/list_awsglue.md
@@ -33,7 +33,7 @@ The following resource types are defined by this service and can be used in the 
 
 | Resource Types | ARN | Condition Keys | 
 | --- | --- | --- | 
-|   [ catalog ](https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html)  |  arn:$\{Partition\}:glue:$\{Region\}:$\{Account\}:catalog/$\{CatalogName\}  |  | 
+|   [ catalog ](https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html)  |  arn:$\{Partition\}:glue:$\{Region\}:$\{Account\}:catalog  |  | 
 |   [ database ](https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html)  |  arn:$\{Partition\}:glue:$\{Region\}:$\{Account\}:database/$\{DatabaseName\}  |  | 
 |   [ table ](https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html)  |  arn:$\{Partition\}:glue:$\{Region\}:$\{Account\}:table/$\{TableName\}  |  | 
 |   [ tableversion ](https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html)  |  arn:$\{Partition\}:glue:$\{Region\}:$\{Account\}:tableVersion/$\{TableVersionName\}  |  | 


### PR DESCRIPTION



*Issue #, if available:*

*Description of changes:*Data Catalog ARN is incorrect in the documentation as reported by one of our customer.  Please correct the documentation.
Existing ARN - for Catalog resource Type - arn:${Partition}:glue:${Region}:${Account}:catalog/${CatalogName}
Correct ARN - arn:${Partition}:glue:${Region}:${Account}:catalog
For example: arn:aws:glue:us-east-1:123456789012:catalog
Source - https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html#data-catalog-resource-arns

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
