### PR TITLE
Updated iam-user-guide/reference_identifiers

### DIFF
--- a/doc_source/reference_identifiers.md
+++ b/doc_source/reference_identifiers.md
@@ -13,7 +13,7 @@ When you create a user, a role, a group, or a policy, or when you upload a serve
 
 If you are using the IAM API or AWS Command Line Interface \(AWS CLI\) to create IAM entities, you can also give the entity an optional path\. You can use a single path, or nest multiple paths as if they were a folder structure\. For example, you could use the nested path `/division_abc/subdivision_xyz/product_1234/engineering/` to match your company's organizational structure\. You could then create a policy to allow all users in that path to access the policy simulator API\. To view this policy, see [IAM: Access the Policy Simulator API Based on User Path](reference_policies_examples_iam_policy-sim-path.md)\. For additional examples of how you might use paths, see [IAM ARNs](#identifiers-arns)\.
 
-When you use AWS CloudFormation to create resources, you can specify a path for users, groups, and roles, but not policies\.
+When you use AWS CloudFormation to create resources, you can specify a path for users, groups, roles, and managed policies\.
 
 Just because you give a user and group the same path doesn't automatically put that user in that group\. For example, you might create a Developers group and specify its path as /division\_abc/subdivision\_xyz/product\_1234/engineering/\. Just because you create a user named Bob and give him that same path doesn't automatically put Bob in the Developers group\. IAM doesn't enforce any boundaries between users or groups based on their paths\. Users with different paths can use the same resources \(assuming they've been granted permission to those resources\)\. For information about limitations on names, see [IAM and STS Limits](reference_iam-limits.md)\.
 


### PR DESCRIPTION
Managed Policies do support specifying a Path through cloudformation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
