### PR TITLE
Update tutorial_attribute-based-access-control.md

### DIFF
--- a/doc_source/tutorial_attribute-based-access-control.md
+++ b/doc_source/tutorial_attribute-based-access-control.md
@@ -218,7 +218,7 @@ The permissions policy attached to the roles allows the employees to create secr
 
 1. Attempt to switch to the `access-uni-engineering` role\. For more information about switching roles in the AWS Management Console, see [Switching to a Role \(Console\)](id_roles_use_switch-role-console.md)\.
 
-   This operation fails because the `access-team` tag values do not match on the user and role\.
+   This operation fails because the `access-project` and `cost-center` tag values do not match for the `access-Arnav-peg-eng` user and `access-uni-engineering` role\.
 
 1. Switch to the `access-peg-engineering` role\. For more information about switching roles in the AWS Management Console, see [Switching to a Role \(Console\)](id_roles_use_switch-role-console.md)\.
 


### PR DESCRIPTION
*Description of changes:* Revised the language to fix a description that seems _exactly backwards:_ with the way that this tutorial was set up, the `access-team` tag is tag is the only tag that _does_ match between `user` and `role`. The reason this fails is because the two `access-project` and `cost-center` tags don't match.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
