### PR TITLE
Fix to get sign-in token parameter

### DIFF
--- a/doc_source/id_roles_providers_enable-console-custom-url.md
+++ b/doc_source/id_roles_providers_enable-console-custom-url.md
@@ -174,7 +174,7 @@ json_string_with_temp_credentials = json.dumps(url_credentials)
 # the sign-in action request, a 12-hour session duration, and the JSON document with temporary credentials 
 # as parameters.
 request_parameters = "?Action=getSigninToken"
-request_parameters += "&SessionDuration=43200"
+request_parameters += "&DurationSeconds=43200"
 if sys.version_info[0] < 3:
     def quote_plus_function(s):
         return urllib.quote_plus(s)


### PR DESCRIPTION
*Issue #, if available:*
I got an error when I used original parameter name.

*Description of changes:*
Fix incorrect parameter name. I could work this script the below environment:

```
% python3 --version
Python 3.7.3

% pip3 list       
Package         Version  
--------------- ---------
awscli          1.18.134 
boto3           1.14.57  
botocore        1.17.57  
certifi         2020.6.20
chardet         3.0.4    
colorama        0.4.1    
docutils        0.15.2   
idna            2.10     
jmespath        0.9.4    
pip             19.0.3   
pyasn1          0.4.8    
python-dateutil 2.8.1    
PyYAML          5.2      
requests        2.24.0   
rsa             3.4.2    
s3transfer      0.3.2    
setuptools      40.8.0   
six             1.12.0   
urllib3         1.25.8   
wheel           0.33.1   
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
