### PR TITLE
Allow users to change their passwords before setting up MFA in reference_policies_examples_aws_my-sec-creds-self-manage.md

### DIFF
--- a/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage.md
+++ b/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage.md
@@ -120,6 +120,7 @@ This policy does not allow users to view the **Users** page in the IAM console o
             "Sid": "DenyAllExceptListedIfNoMFA",
             "Effect": "Deny",
             "NotAction": [
+                "iam:ChangePassword",
                 "iam:CreateVirtualMFADevice",
                 "iam:EnableMFADevice",
                 "iam:GetUser",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow users to change their passwords before setting up MFA. This is necessary for initial login if the IAM account was created with **Require password reset** checked in the console

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
