### PR TITLE
Changes to DenyAllExceptListedIfNoMFA Section

### DIFF
--- a/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage.md
+++ b/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage.md
@@ -121,6 +121,7 @@ This policy does not allow users to view the **Users** page in the IAM console o
             "Effect": "Deny",
             "NotAction": [
                 "iam:CreateVirtualMFADevice",
+                "iam:DeleteVirtualMFADevice",
                 "iam:EnableMFADevice",
                 "iam:GetUser",
                 "iam:ListMFADevices",


### PR DESCRIPTION
A user can not create an MFA in the AWS console without the "iam:DeleteVirtualMFADevice" permission as they will get an error for "Entity Already Exists".  This permission should be included so users can configure their own virtual MFA device.

*Issue #, if available: n/a*

*Description of changes: Adds delete virtual mfa device to the allowed action when MFA is not present to allow creation of MFA device in the AWS console.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
