### PR TITLE
fix typo in event example

### DIFF
--- a/doc_source/cloudtrail-integration.md
+++ b/doc_source/cloudtrail-integration.md
@@ -143,7 +143,7 @@ The following example shows a CloudTrail log entry for a request made for the IA
     "arn": "arn:aws:iam::444455556666:user/JaneDoe",
     "accountId": "444455556666",
     "accessKeyId": "AKIAI44QH8DHBEXAMPLE",
-    "userName": "JameDoe",
+    "userName": "JaneDoe",
     "sessionContext": {
       "attributes": {
         "mfaAuthenticated": "false",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Under "Example IAM API event in CloudTrail log file",`userIdentity.userName` should match the username in the `arn`: `JaneDoe` instead of `JameDoe`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
