### PR TITLE
Group name information update

### DIFF
--- a/doc_source/id_groups_create.md
+++ b/doc_source/id_groups_create.md
@@ -12,7 +12,7 @@ For information about the permissions that you need in order to create a group, 
 
 1. In the **Group Name** box, type the name of the group and then click **Next Step**\.
 **Note**  
-The number and size of IAM resources in an AWS account are limited\. For more information, see [IAM and STS quotas](reference_iam-quotas.md)\. Group names can be a combination of up to 64 letters, digits, and these characters: plus \(\+\), equal \(=\), comma \(,\), period \(\.\), at sign \(@\), underscore \(\_\), and hyphen \(\-\)\. Names must be unique within an account\. They are not distinguished by case\. For example, you cannot create groups named both **ADMINS** and **admins**\.
+The number and size of IAM resources in an AWS account are limited\. For more information, see [IAM and STS quotas](reference_iam-quotas.md)\. Group names can be a combination of up to 128 letters, digits, and these characters: plus \(\+\), equal \(=\), comma \(,\), period \(\.\), at sign \(@\), underscore \(\_\), and hyphen \(\-\)\. Names must be unique within an account\. They are not distinguished by case\. For example, you cannot create groups named both **ADMINS** and **admins**\.
 
 1. In the list of policies, select the check box for each policy that you want to apply to all members of the group\. Then click **Next Step**\.
 


### PR DESCRIPTION
Maximum characters in a group name can be up to 128 characters.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
