### PR TITLE
Update reference_policies_examples_iam_read-only-console-no-reporting.md

### DIFF
--- a/doc_source/reference_policies_examples_iam_read-only-console-no-reporting.md
+++ b/doc_source/reference_policies_examples_iam_read-only-console-no-reporting.md
@@ -1,6 +1,6 @@
 # IAM: Allows read\-only access to the IAM console without reporting<a name="reference_policies_examples_iam_read-only-console-no-reporting"></a>
 
-This example shows how you might create an IAM policy that allows IAM users to perform any IAM action that begins with the string `Get`, `List`, or `Generate`\. As users work with the console, the console makes requests to IAM to list groups, users, roles, and policies, and to generate reports about those resources\.
+This example shows how you might create an IAM policy that allows IAM users to perform any IAM action that begins with the string `Get`, `List`, or `Generate`\. As users work with the console, the console makes requests to IAM to list groups, users, roles, and policies\.
 
 The asterisk acts as a wildcard\. When you use `iam:Get*` in a policy, the resulting permissions include all IAM actions that begin with `Get`, such as `GetUser` and `GetRole`\. Wildcards are useful if new types of entities are added to IAM in the future\. In that case, the permissions granted by the policy automatically allow the user to list and get the details about those new entities\. 
 
@@ -13,8 +13,7 @@ This policy can't be used for reporting purposes\.
         "Effect": "Allow",
         "Action": [
             "iam:Get*",
-            "iam:List*",
-            "iam:Generate*"
+            "iam:List*"
         ],
         "Resource": "*"
     }


### PR DESCRIPTION
The title says "without reporting", so `iam:Generate*` should be excluded.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
