### PR TITLE
Update reference_policies_examples_s3_cognito-bucket.md

### DIFF
--- a/doc_source/reference_policies_examples_s3_cognito-bucket.md
+++ b/doc_source/reference_policies_examples_s3_cognito-bucket.md
@@ -16,7 +16,7 @@ The 'sub' value used in the object key is not the user's sub value in the User P
             "Resource": ["arn:aws:s3:::bucket-name"],
             "Condition": {
                 "StringLike": {
-                    "s3:prefix": ["cognito/application-name/${cognito-identity.amazonaws.com:sub}"]
+                    "s3:prefix": ["cognito/application-name/${cognito-identity.amazonaws.com:sub}/*"]
                 }
             }
         },


### PR DESCRIPTION
`s3:prefix` should be terminated with `/` and it also should contain "sub-directories" (child prefixes)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
