### PR TITLE
Update reference_policies_examples_aws_my-sec-creds-self-manage-mfa-o…

### DIFF
--- a/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.md
+++ b/doc_source/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.md
@@ -57,6 +57,7 @@ Do not add permission to delete an MFA device without MFA authentication\. Users
             "Sid": "DenyAllExceptListedIfNoMFA",
             "Effect": "Deny",
             "NotAction": [
+                "iam:ChangePassword",
                 "iam:CreateVirtualMFADevice",
                 "iam:EnableMFADevice",
                 "iam:GetUser",


### PR DESCRIPTION
…nly.md

Updates the policy to allow password change for users without MFA. When creating new IAM users and requiring them to change their password, these users need permission to change their password prior to setting up MFA.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
