### PR TITLE
Update id_roles_manage_delete.md

### DIFF
--- a/doc_source/id_roles_manage_delete.md
+++ b/doc_source/id_roles_manage_delete.md
@@ -50,7 +50,7 @@ If the service does not include documentation for deleting the service\-linked r
 
 ## Deleting an IAM role \(console\)<a name="roles-managingrole-deleting-console"></a>
 
-When you use the AWS Management Console to delete a role, IAM also automatically deletes the policies associated with the role\. It also deletes any Amazon EC2 instance profile that contains the role\.
+When you use the AWS Management Console to delete a role, IAM also automatically deletes any Amazon EC2 instance profile that contains the role\.
 
 **Important**  
 In some cases, a role might be associated with an Amazon EC2 instance profile, and the role and the instance profile might have the same name\. In that case you can use the AWS Management Console to delete the role and the instance profile\. This linkage happens automatically for roles and instance profiles that you create in the console\. If you created the role from the AWS CLI, Tools for Windows PowerShell, or the AWS API, then the role and the instance profile might have different names\. In that case you cannot use the console to delete them\. Instead, you must use the AWS CLI, Tools for Windows PowerShell, or AWS API to first remove the role from the instance profile\. You must then take a separate step to delete the role\.


### PR DESCRIPTION
When a Role is deleted, the attached policies are not deleted automatically, only the instance profile is deleted.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
