### PR TITLE
Fix typo in policy JSON

### DIFF
--- a/doc_source/reference_policies_examples_iam_read-only-console-no-reporting.md
+++ b/doc_source/reference_policies_examples_iam_read-only-console-no-reporting.md
@@ -13,7 +13,7 @@ This policy cannot be used to generate reports or service last accessed details\
         "Effect": "Allow",
         "Action": [
             "iam:Get*",
-            "iam:List*",
+            "iam:List*"
         ],
         "Resource": "*"
     }


### PR DESCRIPTION
Fix stray trailing comma in policy document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
