### PR TITLE
Update EC2 Security Groups VPC example policy to work with the July 7, 2021 updates

### DIFF
--- a/doc_source/reference_policies_examples_ec2_securitygroups-vpc.md
+++ b/doc_source/reference_policies_examples_ec2_securitygroups-vpc.md
@@ -13,7 +13,8 @@ This example shows how you might create an IAM policy that allows managing Amazo
                 "ec2:AuthorizeSecurityGroupIngress",
                 "ec2:DeleteSecurityGroup",
                 "ec2:RevokeSecurityGroupEgress",
-                "ec2:RevokeSecurityGroupIngress"
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:ModifySecurityGroupRules"
             ],
             "Resource": "arn:aws:ec2:*:*:security-group/*",
             "Condition": {
@@ -27,7 +28,8 @@ This example shows how you might create an IAM policy that allows managing Amazo
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSecurityGroupReferences",
                 "ec2:DescribeStaleSecurityGroups",
-                "ec2:DescribeVpcs"
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSecurityGroupRules"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Modifies policy to work as intended after ec2:ModifySecurityGroupRules and ec2:DescribeSecurityGroupRules were introduced (https://aws.amazon.com/blogs/aws/easily-manage-security-group-rules-with-the-new-security-group-rule-id/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
