### PR TITLE
Update reference_identifiers.md

### DIFF
--- a/doc_source/reference_identifiers.md
+++ b/doc_source/reference_identifiers.md
@@ -29,7 +29,7 @@ Where:
 + `partition` identifies the partition that the resource is in\. For standard AWS Regions, the partition is `aws`\. If you have resources in other partitions, the partition is `aws-partitionname`\. For example, the partition for resources in the China \(Beijing\) Region is `aws-cn`\. You cannot [delegate access](id_roles_compare-resource-policies.md#aboutdelegation-resourcepolicy) between accounts in different partitions\.
 + `service` identifies the AWS product\. For IAM resources, this is always `iam`\.
 + `region` is the Region the resource resides in\. For IAM resources, this is always kept blank\.
-+ `account` is the AWS account ID with no hyphens or the alias for the AWS account\.
++ `account` is the AWS account ID with no hyphens\.
 + `resource` is the portion that identifies the specific resource by name\.
 
 You can specify IAM and AWS STS ARNs using the following syntax\. The Region portion of the ARN is blank because IAM resources are global\. 


### PR DESCRIPTION


*Issue #, if available:* N/A

*Description of changes:*
This doc says that the `account` section of the ARN format allows the account alias as well. That seems to be incorrect based on the below link and my experience when I tried to reference the account alias instead of account id.

https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
