### PR TITLE
Update access_policies_access-advisor-view-data.md

### DIFF
--- a/doc_source/access_policies_access-advisor-view-data.md
+++ b/doc_source/access_policies_access-advisor-view-data.md
@@ -44,7 +44,7 @@ You can use the AWS CLI to retrieve information about the last time that an IAM 
 **To view information for IAM \(AWS CLI\)**
 
 1. Generate a report\. The request must include the ARN of the IAM resource \(user, user group, role, or policy\) for which you want a report\. You can specify the level of granularity that you want to generate in the report to view access details for either services or both services and actions\. The request returns a `job-id` that you can then use in the `get-service-last-accessed-details` and `get-service-last-accessed-details-with-entities` operations to monitor the `job-status` until the job is complete\.
-   + [aws iam generate\-service\-last\-accessed\-details](https://docs.aws.amazon.com/cli/latest/reference/iam/generate-service-last-accessed-details.html)
+   + [aws iam generate\-service\-last\-accessed\-details](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/generate-service-last-accessed-details.html)
 
 1. Retrieve details about the report using the `job-id` parameter from the previous step\.
    + [aws iam get\-service\-last\-accessed\-details](https://docs.aws.amazon.com/cli/latest/reference/iam/get-service-last-accessed-details.html)


### PR DESCRIPTION
I noted that this URL and others point to AWS docs with a message stating: ```AWS CLI version 2, the latest major version of AWS CLI, is now stable and recommended for general use. To view this page for the AWS CLI version 2, click here. For more information see the AWS CLI version 2 installation instructions and migration guide.```

if this is true then the URL should probably point to the new docs, and the other URLs in this doc should be updated. I did note though that the original URL points to `/latest`, so maybe this should be updated elsewhere in AWS docs and this PR closed instead?

*Issue #, if available:* not available

*Description of changes:* see above


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
