### PR TITLE
Update access-analyzer-policy-generation.md

### DIFF
--- a/doc_source/access-analyzer-policy-generation.md
+++ b/doc_source/access-analyzer-policy-generation.md
@@ -340,7 +340,7 @@ To successfully generate a policy, the objects in the bucket must be owned by th
          ],
          "Resource": [
            "arn:aws:s3:::DOC-EXAMPLE-BUCKET",
-           "arn:aws:s3:::DOC-EXAMPLE-BUCKET/AWSLogs/organization-id/${aws:PrincipalAccount}/*"
+           "arn:aws:s3:::DOC-EXAMPLE-BUCKET/organization-id/AWSLogs/${aws:PrincipalAccount}/*"
          ],
          "Condition": {
            "StringEquals": {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The provided sample arn is incorrect. According to the docs for creating an organizational trail at  [https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html), "the high-level bucket structure for log files contains a folder _**named with the organization ID**_, and subfolders named with the account IDs for each account in the organization."

 This pr fixes the arn to reflect the structure as described above. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
