### PR TITLE
Fix Typo in reference_policies_iam-condition-keys.md 

### DIFF
--- a/doc_source/reference_policies_iam-condition-keys.md
+++ b/doc_source/reference_policies_iam-condition-keys.md
@@ -105,7 +105,7 @@ You can use web identity federation to give temporary security credentials to us
 
 **amr**  
 Works with [string operators](reference_policies_elements_condition_operators.md#Conditions_String)\.  
-**Example**: `cognito-identity.amazonaws.com.com:amr`  
+**Example**: `cognito-identity.amazonaws.com:amr`  
 If you are using Amazon Cognito for web identity federation, the `cognito-identity.amazonaws.com:amr` key \(Authentication Methods Reference\) includes login information about the user\. The key is multivalued, meaning that you test it in a policy using [condition set operators](reference_policies_multi-value-conditions.md)\. The key can contain the following values:   
 + If the user is unauthenticated, the key contains only `unauthenticated`\.
 + If the user is authenticated, the key contains the value `authenticated` and the name of the login provider used in the call \(`graph.facebook.com`, `accounts.google.com`, or `www.amazon.com`\)\. 


### PR DESCRIPTION
Simple Typo correction

Removed duplicate `.com.com` in the [Available keys for AWS web identity federation section](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#condition-keys-wif)
`cognito-identity.amazonaws.com.com:amr` should be `cognito-identity.amazonaws.com:amr` as shown on the next line

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/61847/187285429-2bb66dea-a2ae-47fd-afcf-a84df046c135.png">
