### PR TITLE
Use correct CloudTrail s3 log folder structure

### DIFF
--- a/doc_source/access-analyzer-policy-generation.md
+++ b/doc_source/access-analyzer-policy-generation.md
@@ -343,7 +343,7 @@ To successfully generate a policy, the objects in the bucket must be owned by th
          ],
          "Resource": [
            "arn:aws:s3:::DOC-EXAMPLE-BUCKET",
-           "arn:aws:s3:::DOC-EXAMPLE-BUCKET/AWSLogs/organization-id/${aws:PrincipalAccount}/*"
+           "arn:aws:s3:::DOC-EXAMPLE-BUCKET/organization-id/AWSLogs/${aws:PrincipalAccount}/*"
          ],
          "Condition": {
            "StringEquals": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This commit amends the existing incorrect AWS CloudTrail S3 bucket folder structure to match the correct folder structure

The folder structure cascades in the following manner;

* `<organisation-id>`
  * `AWSLogs`
    * `<account-id>`

The existing documentation has the `AWSLogs` and `<organization-id>` in the incorrect order

**Changes**

* Corrected the permission structure to actually allow permission to `GetObjects` from the CloudTrail bucket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
