### PR TITLE
Specify that fingerprint from openssl command needs to be SHA1

### DIFF
--- a/doc_source/id_roles_providers_create_oidc_verify-thumbprint.md
+++ b/doc_source/id_roles_providers_create_oidc_verify-thumbprint.md
@@ -69,7 +69,7 @@ AWS secures communication with some OIDC identity providers \(IdPs\) through our
 1. Use the OpenSSL command line tool to run the following command\. 
 
    ```
-   openssl x509 -in certificate.crt -fingerprint -noout
+   openssl x509 -in certificate.crt -fingerprint -sha1 -noout
    ```
 
    Your command window displays the certificate thumbprint, which looks similar to the following example:


### PR DESCRIPTION
*Issue #287*

*Description of changes:*

Added "-sha1" parameter to the openssl command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
