### PR TITLE
Update reference_policies_iam-condition-keys.md

### DIFF
--- a/doc_source/reference_policies_iam-condition-keys.md
+++ b/doc_source/reference_policies_iam-condition-keys.md
@@ -27,7 +27,7 @@ Use this condition key in a policy to allow an entity to pass a role, but only i
     "Resource": "*",
     "Condition": {
         "StringEquals": {"iam:PassedToService": "ec2.amazonaws.com"},
-        "StringLike": {
+        "ArnLike": {
             "iam:AssociatedResourceARN": [
                 "arn:aws:ec2:us-east-1:111122223333:instance/*",
                 "arn:aws:ec2:us-west-1:111122223333:instance/*"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
****
Example for condition key iam:AssociatedResourceArn (works with ARN operators) should be using "ArnLike" (an ARN operator) instead of "StringLike" (not an ARN operator).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
