### PR TITLE
Add troubleshooting section for federated url

### DIFF
--- a/doc_source/example_sts_Scenario_ConstructFederatedUrl_section.md
+++ b/doc_source/example_sts_Scenario_ConstructFederatedUrl_section.md
@@ -150,4 +150,10 @@ def usage_demo():
 
 ------
 
+## Troubleshooting
+### The endpoint `https://signin.aws.amazon.com/federation` returns status code 400 without additional error messages.
+If you encounter a 400 status code error without any additional error messages when accessing the https://signin.aws.amazon.com/federation endpoint, the issue might be related to the `SessionDuration` setting.
+
+The default `str(datetime.timedelta(hours=12).seconds)` will only work for IAM users. If you are using an IAM role, you will hit the 1 hour session limit for role chaining. To verify if this is the cause of the issue, you can try setting the session duration to a value slightly lower than 3600 seconds (e.g. 3590 seconds). Note that setting it to exactly 3600 seconds will not work.
+
 For a complete list of AWS SDK developer guides and code examples, see [Using IAM with an AWS SDK](sdk-general-information-section.md)\. This topic also includes information about getting started and details about previous SDK versions\.

--- a/doc_source/example_sts_Scenario_ConstructFederatedUrl_section.md
+++ b/doc_source/example_sts_Scenario_ConstructFederatedUrl_section.md
@@ -151,9 +151,9 @@ def usage_demo():
 ------
 
 ## Troubleshooting
-### The endpoint `https://signin.aws.amazon.com/federation` returns status code 400 without additional error messages.
-If you encounter a 400 status code error without any additional error messages when accessing the https://signin.aws.amazon.com/federation endpoint, the issue might be related to the `SessionDuration` setting.
+### The endpoint `https://signin.aws.amazon.com/federation` returns status code 400 without additional error messages\.
+If you encounter a 400 status code error without any additional error messages when accessing the `https://signin.aws.amazon.com/federation` endpoint, the issue might be related to the `SessionDuration` setting\.
 
-The default `str(datetime.timedelta(hours=12).seconds)` will only work for IAM users. If you are using an IAM role, you will hit the 1 hour session limit for role chaining. To verify if this is the cause of the issue, you can try setting the session duration to a value slightly lower than 3600 seconds (e.g. 3590 seconds). Note that setting it to exactly 3600 seconds will not work.
+The default `str(datetime.timedelta(hours=12).seconds)` will only work for IAM users\. If you are using an IAM role, you will hit the 1 hour session limit for role chaining\. To verify if this is the cause of the issue, you can try setting the session duration to a value slightly lower than 3600 seconds \(e\.g\. 3590 seconds\)\. Note that setting it to exactly 3600 seconds will not work\.
 
 For a complete list of AWS SDK developer guides and code examples, see [Using IAM with an AWS SDK](sdk-general-information-section.md)\. This topic also includes information about getting started and details about previous SDK versions\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hi,

I have made some changes to address an issue related to the default SessionDuration setting that causes the https://signin.aws.amazon.com/federation endpoint to return a 400 status code when using an IAM role



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
